### PR TITLE
Add install target to CMake configuration

### DIFF
--- a/CvPlot/CMakeLists.txt
+++ b/CvPlot/CMakeLists.txt
@@ -114,3 +114,17 @@ if(CVPLOT_WITH_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+#Install targets
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/inc/${target}"
+        DESTINATION include
+        FILES_MATCHING
+        PATTERN "*.h" PATTERN "*.ipp")
+
+if(NOT CVPLOT_HEADER_ONLY)
+    install(TARGETS ${target}
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib)
+endif()
+
+
+


### PR DESCRIPTION
Minimal addition to base (non-conan) CMake configuration providing a simple install target. All headers and header-implementations, as well as compiled static library when `CVPLOT_HEADER_ONLY` is disabled, installed to `CMAKE_INSTALL_PREFIX`. 