### PR TITLE
Selection internal Hershey fonts

### DIFF
--- a/CvPlot/CMakeLists.txt
+++ b/CvPlot/CMakeLists.txt
@@ -6,6 +6,13 @@ set(target CvPlot)
 project (${target} CXX)
 
 option(CVPLOT_HEADER_ONLY "Use as header only library" ON)
+option(CVPLOT_UNICODE "Enable unicode font" OFF)
+if(CVPLOT_UNICODE)
+  set(CVPLOT_FONT FONT_HERSHEY_COMPLEX)
+else()
+  set(CVPLOT_FONT FONT_HERSHEY_SIMPLEX)
+endif()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/inc/CvPlot/common.h.in common.h)
 
 if(CVPLOT_HEADER_ONLY)
     set(empty_or_interface INTERFACE)
@@ -80,6 +87,7 @@ target_sources(${target} ${public_or_interface}
 
 add_library(${target}::${target} ALIAS ${target})
 target_include_directories(${target} ${public_or_interface} ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+target_include_directories(${target} ${public_or_interface} ${CMAKE_CURRENT_BINARY_DIR})
 
 if(CVPLOT_HEADER_ONLY)
     target_compile_definitions(${target} INTERFACE CVPLOT_HEADER_ONLY)
@@ -117,6 +125,7 @@ endif()
 #Install
 if(CVPLOT_HEADER_ONLY)
 	install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/inc/CvPlot" DESTINATION include)
+	install(FILES "${CMAKE_CURRENT_BINARY_DIR}/common.h" DESTINATION include)
 else()
 	install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/inc/CvPlot" DESTINATION include PATTERN "imp" EXCLUDE)
 endif()

--- a/CvPlot/inc/CvPlot/common.h.in
+++ b/CvPlot/inc/CvPlot/common.h.in
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <opencv2/imgproc.hpp>
+
+#cmakedefine CVPLOT_FONT cv::@CVPLOT_FONT@

--- a/CvPlot/inc/CvPlot/imp/Title.ipp
+++ b/CvPlot/inc/CvPlot/imp/Title.ipp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <common.h>
+
 #include <CvPlot/drawables/Title.h>
 #include <CvPlot/Internal/util.h>
 #include <opencv2/opencv.hpp>
@@ -12,7 +14,7 @@ namespace CvPlot {
 class Title::Impl {
 public:
     std::string _title;
-    const int _fontFace = cv::FONT_HERSHEY_SIMPLEX;
+    const int _fontFace = CVPLOT_FONT;
     const double _fontScale = .4;
     const int _fontThickness = 1;
     cv::Scalar _color = cv::Scalar(0, 0, 0);

--- a/CvPlot/inc/CvPlot/imp/XAxis.ipp
+++ b/CvPlot/inc/CvPlot/imp/XAxis.ipp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <common.h>
+
 #include <CvPlot/drawables/XAxis.h>
 #include <CvPlot/Internal/util.h>
 #include <opencv2/opencv.hpp>
@@ -11,7 +13,7 @@ namespace CvPlot {
 
 class XAxis::Impl {
 public:
-    const int _fontFace = cv::FONT_HERSHEY_SIMPLEX;
+    const int _fontFace = CVPLOT_FONT;
     const double _fontScale = .4;
     const int _fontThickness = 1;
     cv::Scalar _color = cv::Scalar(0, 0, 0);

--- a/CvPlot/inc/CvPlot/imp/XLabel.ipp
+++ b/CvPlot/inc/CvPlot/imp/XLabel.ipp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <common.h>
+
 #include <CvPlot/drawables/XLabel.h>
 #include <CvPlot/Internal/util.h>
 #include <opencv2/opencv.hpp>
@@ -12,7 +14,7 @@ namespace CvPlot {
 class XLabel::Impl {
 public:
     std::string _label;
-    const int _fontFace = cv::FONT_HERSHEY_SIMPLEX;
+    const int _fontFace = CVPLOT_FONT;
     const double _fontScale = .4;
     const int _fontThickness = 1;
     cv::Scalar _color = cv::Scalar(0, 0, 0);

--- a/CvPlot/inc/CvPlot/imp/YAxis.ipp
+++ b/CvPlot/inc/CvPlot/imp/YAxis.ipp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <common.h>
+
 #include <CvPlot/drawables/YAxis.h>
 #include <CvPlot/Internal/util.h>
 #include <opencv2/opencv.hpp>
@@ -11,7 +13,7 @@ namespace CvPlot {
 
 class YAxis::Impl {
 public:
-    const int _fontFace = cv::FONT_HERSHEY_SIMPLEX;
+    const int _fontFace = CVPLOT_FONT;
     const double _fontScale = .4;
     const int _fontThickness = 1;
     bool _locateRight = false;

--- a/CvPlot/inc/CvPlot/imp/YLabel.ipp
+++ b/CvPlot/inc/CvPlot/imp/YLabel.ipp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <common.h>
+
 #include <CvPlot/drawables/YLabel.h>
 #include <CvPlot/Internal/util.h>
 #include <opencv2/opencv.hpp>
@@ -12,7 +14,7 @@ namespace CvPlot {
 class YLabel::Impl {
 public:
     std::string _label;
-    const int _fontFace = cv::FONT_HERSHEY_SIMPLEX;
+    const int _fontFace = CVPLOT_FONT;
     const double _fontScale = .4;
     const int _fontThickness = 1;
     cv::Scalar _color = cv::Scalar(0, 0, 0);

--- a/CvPlot/inc/CvPlot/imp/util.ipp
+++ b/CvPlot/inc/CvPlot/imp/util.ipp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <common.h>
+
 #include <CvPlot/Internal/util.h>
 #include <opencv2/opencv.hpp>
 
@@ -244,7 +246,7 @@ void paint(const cv::Mat3b &src, cv::Mat3b &dst, const cv::Rect2d &pos, int inte
 
     //text
     if (!data.empty() && kx > 20 && ky > 20) {
-        const int fontFace = cv::FONT_HERSHEY_SIMPLEX;
+        const int fontFace = CVPLOT_FONT;
         const double fontScale = .4;
         const int fontThickness = 1;
         const cv::Size maxTextSize((int)kx - 5, (int)ky - 5);


### PR DESCRIPTION
Proposal for a small switch for internal Hershey fonts, i.e. it's switch between ascii (default) and unicode fonts for opencv/4.*. 
Possible solution for #32. 